### PR TITLE
Add column widths checking and refactor code

### DIFF
--- a/rapidtables/__init__.py
+++ b/rapidtables/__init__.py
@@ -97,13 +97,16 @@ def format_table(table,
     if fmt == OUTPUT_RAW:
         result = ''
 
-    if isinstance(column_width, (int, float)):
+    if column_width in [True, None]:
+        # need to determine widths
+        key_lengths = guess_widths(keys, headers, columns_to_use, generate_header)
+    elif isinstance(column_width, (int, float)):
+        print(column_width)
         key_lengths = (column_width,) * len_keys
     elif isinstance(column_width, (tuple, list)):
         key_lengths = column_width
     else:
-        # need to determine widths
-        key_lengths = guess_widths(keys, headers, columns_to_use, generate_header)
+        raise ValueError("Unrecognized 'column_width'")
 
     # figure out alphas
     for ki, k in enumerate(keys):

--- a/rapidtables/__init__.py
+++ b/rapidtables/__init__.py
@@ -125,7 +125,9 @@ def format_table(table,
             header = ''
             if need_body_sep:
                 bsep = ''
-            for i, ht, key_len in zip(lkr, headers, key_lengths):
+            for i in lkr:
+                ht = headers[i]
+                key_len = key_lengths[i]
                 if need_body_sep:
                     if i < len_keysn:
                         bsep += body_sep * key_len + body_sep_fill

--- a/rapidtables/__init__.py
+++ b/rapidtables/__init__.py
@@ -2,6 +2,8 @@ __author__ = "Altertech"
 __license__ = "MIT"
 __version__ = '0.0.34'
 
+from itertools import chain
+
 OUTPUT_RAW = 0
 OUTPUT_GENERATOR = 1
 OUTPUT_GENERATOR_TUPLES = 2
@@ -152,7 +154,7 @@ def format_table(table,
                     header += (ht.rjust(key_len),)
 
     def body_generator():
-        for v in table:
+        for v in chain((first_row,), table):
             if fmt == OUTPUT_GENERATOR_TUPLES:
                 row = ()
             else:


### PR DESCRIPTION
So this is kind of what I was thinking for #1. I got kind of out of control and refactored a ton of the code, but am seeing some major improvements on my machine. I screwed something up and the second row (the one with the `-`) doesn't seem to be the right length.

However, the main feature here as far as performance comes if you set `column_widths=True`. This only uses the first row of data to determine the column widths and keeps the table as a generator. I also changed the alpha determining code to always only use the first row. I didn't see a reason for it to use every row if we assume column types are consistent.

Working on fixing the output...let me know what you think otherwise. Sorry this only made it in one commit.