### PR TITLE
Text wrapping

### DIFF
--- a/examples/example_wrap.py
+++ b/examples/example_wrap.py
@@ -1,0 +1,25 @@
+data = [{
+    'rating': 10,
+    'job': 'Spiderman'
+}, {
+    'rating': 9,
+    'job': 'Batman'
+}, {
+    'rating': 8,
+    'job': 'Lords of the rings return of the king extended theatrical edition'
+}, {
+    'rating': 7,
+    'job': 'Superman'
+}]
+
+from rapidtables import print_table
+
+
+print_table(data, allow_multiline=True, tablefmt='simple', max_column_width=10, wrap_text=True)
+print('')
+print_table(data, allow_multiline=True, tablefmt='md', max_column_width=10, wrap_text=True)
+print('')
+print_table(data, allow_multiline=True, tablefmt='rst', max_column_width=10, wrap_text=True)
+print('')
+print_table(data, allow_multiline=True, tablefmt='rstgrid', max_column_width=10, wrap_text=True)
+


### PR DESCRIPTION
## Added an option to wrap text.
Currently, a column with a long string causes the entire row to be very long, and where a horizontal scroll bar is not supported (like in a terminal), this messes up the entire table.
Using `max_column_width` to cap it truncates the text. So I needed an option to keep the entire text and cap the length of the column.

For the given input
```
data = [{
    'rating': 10,
    'job': 'Spiderman'
}, {
    'rating': 9,
    'job': 'Batman'
}, {
    'rating': 8,
    'job': 'Lords of the rings return of the king extended theatrical edition'
}, {
    'rating': 7,
    'job': 'Superman'
}]
print_table(data, allow_multiline=True, tablefmt='rstgrid')
```

The output is:
```
+--------+-------------------------------------------------------------------+
| rating | job                                                               | 
+========+===================================================================+
|     10 | Spiderman                                                         | 
+--------+-------------------------------------------------------------------+
|      9 | Batman                                                            | 
+--------+-------------------------------------------------------------------+
|      8 | Lords of the rings return of the king extended theatrical edition | 
+--------+-------------------------------------------------------------------+
|      7 | Superman                                                          | 
+--------+-------------------------------------------------------------------+
```
If you use `max_column_width`, the text is cut in the middle
```
print_table(data, allow_multiline=True, tablefmt='rstgrid', max_column_width=10)
```

```
+--------+------------+
| rating | job        | 
+========+============+
|     10 | Spiderman  | 
+--------+------------+
|      9 | Batman     | 
+--------+------------+
|      8 | Lords of t | 
+--------+------------+
|      7 | Superman   | 
+--------+------------+
```

Now you can use `wrap_text` to wrap the text:
```
print_table(data, allow_multiline=True, tablefmt='rstgrid', max_column_width=10, wrap_text=True)
```
```
+--------+------------+
| rating | job        | 
+========+============+
|     10 | Spiderman  | 
+--------+------------+
|      9 | Batman     | 
+--------+------------+
|      8 | Lords of   | 
|        | the rings  | 
|        | return of  | 
|        | the king   | 
|        | extended   | 
|        | theatrical | 
|        | edition    | 
+--------+------------+
|      7 | Superman   | 
+--------+------------+
```

This works by cutting with new lines and then using the existing multiline feature (thanks for that :) )
Theoretically, I might want to add wrapping to table keys as well, but thats not for now.

P.s, I didn't add anything to the readme since I saw that the multiline feature is also not there, but I think you should add it.