### PR TITLE
Fix wrapping

### DIFF
--- a/rapidtables/__init__.py
+++ b/rapidtables/__init__.py
@@ -146,7 +146,7 @@ def format_table(table,
                         if dig_colwidth:
                             if multiline != MULTILINE_DENY and isinstance(
                                     value, str):
-                                l = max([len(z) for z in value.split('\n')])
+                                l = max([len(z) for z in value.splitlines() or [""]])
                             else:
                                 l = len(str(value))
                             if max_column_width is None:
@@ -255,14 +255,14 @@ def format_table(table,
                     col_value = v.get(k)
                     if multiline != MULTILINE_DENY and isinstance(
                             col_value, str):
-                        col_vals = col_value.split('\n')
+                        col_vals = col_value.splitlines() or [""]
                         if wrap_text:
                             """
                             Iterate over each line and wrap the text,
                             then combine it all back to a single list.
                             """
                             col_vals = list(chain.from_iterable(
-                                [fill(val, max_column_width).splitlines()
+                                [fill(val, max_column_width).splitlines() or [""]
                                  for val in col_vals]))
                         col_value = col_vals[0]
                         for ci, cv in enumerate(col_vals[1:]):


### PR DESCRIPTION
Changed `.split('\n')` to `.splitlines()` to support different method of line break, like `\r\n` on windows.

Also using an empty value ('') threw an exception when wrapping the text, since 
```python
''.splitlines() - > []
```
To avoid this I added ```or [""]``` making the functionality similar to .split() which returns a list with a single empty string when done on an empty value.

(https://stackoverflow.com/questions/16645083/when-splitting-an-empty-string-in-python-why-does-split-return-an-empty-list)